### PR TITLE
Update metrics profile to capture only current cluster metrics

### DIFF
--- a/kube-burner/metric-profile.yaml
+++ b/kube-burner/metric-profile.yaml
@@ -1,84 +1,87 @@
 # API server
 
-- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
+- query: kubernetes_build_info{cluster="{{.CLUSTER_NAME}}"}
+  metricName: k8sBuildInfo
+
+- query: irate(apiserver_request_total{cluster="{{.CLUSTER_NAME}}", verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
   metricName: schedulingThroughput
 
-- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{cluster="{{.CLUSTER_NAME}}", apiserver="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
   metricName: readOnlyAPICallsLatency
 
-- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{cluster="{{.CLUSTER_NAME}}", apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
   metricName: mutatingAPICallsLatency
 
-- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
+- query: sum(irate(apiserver_request_total{cluster="{{.CLUSTER_NAME}}". apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
   metricName: APIRequestRate
 
 # Kubeproxy and OVN service sync latency
 
-- query: histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket[2m])) by (le)) > 0
+- query: histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster="{{.CLUSTER_NAME}}"}[2m])) by (le)) > 0
   metricName: serviceSyncLatency
 
-- query: histogram_quantile(0.99, sum(rate(ovnkube_master_network_programming_duration_seconds_bucket{kind="service"}[2m])) by (le))
+- query: histogram_quantile(0.99, sum(rate(ovnkube_master_network_programming_duration_seconds_bucket{cluster="{{.CLUSTER_NAME}}", kind="service"}[2m])) by (le))
   metricName: serviceSyncLatency
 
 # Containers & pod metrics
 
-- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!~"POD|",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|network-node-identity|multus|sdn|ingress|.*controller-manager|.*scheduler)|cilium"}[2m]) * 100) by (container, pod, namespace, node)) > 0
+- query: (sum(irate(container_cpu_usage_seconds_total{cluster="{{.CLUSTER_NAME}}", name!="",container!~"POD|",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|network-node-identity|multus|sdn|ingress|.*controller-manager|.*scheduler)|cilium"}[2m]) * 100) by (container, pod, namespace, node)) > 0
   metricName: containerCPU
 
-- query: sum(container_memory_rss{name!="",container!~"POD|",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|network-node-identity|multus|sdn|ingress|.*controller-manager|.*scheduler)|cilium"}) by (container, pod, namespace, node)
+- query: sum(container_memory_rss{cluster="{{.CLUSTER_NAME}}", name!="",container!~"POD|",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|network-node-identity|multus|sdn|ingress|.*controller-manager|.*scheduler)|cilium"}) by (container, pod, namespace, node)
   metricName: containerMemory
 
 # Kubelet & CRI-O runtime metrics
 
-- query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+- query: sum(irate(process_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}", service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
   metricName: kubeletCPU
 
-- query: sum(process_resident_memory_bytes{service="kubelet",job="kubelet"}) by (node) and on (node) kube_node_role{role="worker"}
+- query: sum(process_resident_memory_bytes{cluster="{{.CLUSTER_NAME}}", service="kubelet",job="kubelet"}) by (node) and on (node) kube_node_role{role="worker"}
   metricName: kubeletMemory
 
-- query: sum(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+- query: sum(irate(process_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}", service="kubelet",job="crio"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
   metricName: crioCPU
 
-- query: sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
+- query: sum(process_resident_memory_bytes{cluster="{{.CLUSTER_NAME}}", service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
   metricName: crioMemory
 
-- query: irate(container_runtime_crio_operations_latency_microseconds{operation_type="network_setup_pod"}[2m]) > 0
+- query: irate(container_runtime_crio_operations_latency_microseconds{cluster="{{.CLUSTER_NAME}}", operation_type="network_setup_pod"}[2m]) > 0
   metricName: containerNetworkSetupLatency
 
 # Node metrics: CPU & Memory
 
-- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+- query: (sum(irate(node_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
   metricName: nodeCPU-Workers
 
-- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+- query: (sum(irate(node_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
   metricName: nodeCPU-Masters
 
-- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+- query: (sum(irate(node_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
   metricName: nodeCPU-Infra
 
 # We compute memory utilization by substrating available memory to the total
 
-- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+- query: (node_memory_MemTotal_bytes{cluster="{{.CLUSTER_NAME}}"} - node_memory_MemAvailable_bytes{cluster="{{.CLUSTER_NAME}}"}) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryUtilization-Masters
 
-- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+- query: (node_memory_MemTotal_bytes{cluster="{{.CLUSTER_NAME}}"} - node_memory_MemAvailable_bytes{cluster="{{.CLUSTER_NAME}}"}) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryUtilization-Workers
 
-- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+- query: (node_memory_MemTotal_bytes{cluster="{{.CLUSTER_NAME}}"} - node_memory_MemAvailable_bytes{cluster="{{.CLUSTER_NAME}}"}) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryUtilization-Infra
 
 # Etcd metrics
 
-- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
+- query: sum(rate(etcd_server_leader_changes_seen_total{cluster="{{.CLUSTER_NAME}}"}[2m]))
   metricName: etcdLeaderChangesRate
 
-- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
+- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster="{{.CLUSTER_NAME}}"}[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
 
-- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))
+- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster="{{.CLUSTER_NAME}}"}[2m]))
   metricName: 99thEtcdDiskWalFsyncDurationSeconds
 
-- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
+- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{cluster="{{.CLUSTER_NAME}}"}[5m]))
   metricName: 99thEtcdRoundTripTimeSeconds
 
 - query: sum by (cluster_version)(etcd_cluster_version)
@@ -87,78 +90,78 @@
 
 # Cluster metrics
 
-- query: sum(kube_namespace_status_phase) by (phase) > 0
+- query: sum(kube_namespace_status_phase{cluster="{{.CLUSTER_NAME}}"}) by (phase) > 0
   metricName: namespaceCount
 
-- query: sum(kube_pod_status_phase{}) by (phase)
+- query: sum(kube_pod_status_phase{cluster="{{.CLUSTER_NAME}}"}) by (phase)
   metricName: podStatusCount
 
-- query: count(kube_secret_info{})
+- query: count(kube_secret_info{cluster="{{.CLUSTER_NAME}}"})
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_labels{cluster="{{.CLUSTER_NAME}}"})
   metricName: deploymentCount
   instant: true
 
-- query: count(kube_configmap_info{})
+- query: count(kube_configmap_info{cluster="{{.CLUSTER_NAME}}"})
   metricName: configmapCount
   instant: true
 
-- query: count(kube_service_info{})
+- query: count(kube_service_info{cluster="{{.CLUSTER_NAME}}"})
   metricName: serviceCount
   instant: true
 
-- query: count(openshift_route_created{})
+- query: count(openshift_route_created{cluster="{{.CLUSTER_NAME}}"})
   metricName: routeCount
   instant: true
 
-- query: kube_node_role
+- query: kube_node_role{cluster="{{.CLUSTER_NAME}}"}
   metricName: nodeRoles
 
-- query: sum(kube_node_status_condition{status="true"}) by (condition)
+- query: sum(kube_node_status_condition{cluster="{{.CLUSTER_NAME}}", status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_labels{cluster="{{.CLUSTER_NAME}}", })
   metricName: replicaSetCount
   instant: true
 
-- query: count(kube_pod_info{} AND ON (pod) kube_pod_status_phase{phase="Running"}==1) by (node)
+- query: count(kube_pod_info{cluster="{{.CLUSTER_NAME}}"} AND ON (pod) kube_pod_status_phase{cluster="{{.CLUSTER_NAME}}", phase="Running"}==1) by (node)
   metricName: podDistribution
 
 # Prometheus metrics
 
-- query: openshift:prometheus_tsdb_head_series:sum{job="prometheus-k8s"}
+- query: openshift:prometheus_tsdb_head_series:sum{cluster="{{.CLUSTER_NAME}}", job="prometheus-k8s"}
   metricName: prometheus-timeseriestotal
 
-- query: openshift:prometheus_tsdb_head_samples_appended_total:sum{job="prometheus-k8s"}
+- query: openshift:prometheus_tsdb_head_samples_appended_total:sum{cluster="{{.CLUSTER_NAME}}", job="prometheus-k8s"}
   metricName: prometheus-ingestionrate
 
 # Retain the raw CPU seconds totals for comparison
-- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+- query: sum( node_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}"} and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Workers
   instant: true
 
-- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
+- query: sum( node_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Masters
   instant: true
 
-- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+- query: sum( node_cpu_seconds_total{cluster="{{.CLUSTER_NAME}}"} and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Infra
   instant: true
 
-- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
+- query: sum (  container_cpu_usage_seconds_total{cluster="{{.CLUSTER_NAME}}"} {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{cluster="{{.CLUSTER_NAME}}", role = "worker",role != "infra" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Workers
   instant: true
 
-- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
+- query: sum (  container_cpu_usage_seconds_total {cluster="{{.CLUSTER_NAME}}", id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{cluster="{{.CLUSTER_NAME}}", role = "master" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Masters
   instant: true
 
-- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
+- query: sum (  container_cpu_usage_seconds_total {cluster="{{.CLUSTER_NAME}}", id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{cluster="{{.CLUSTER_NAME}}", role = "infra" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Infra
   instant: true
 
-- query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
+- query: sum( container_cpu_usage_seconds_total{cluster="{{.CLUSTER_NAME}}", container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
   metricName: cgroupCPUSeconds-namespaces
   instant: true


### PR DESCRIPTION
AKS prometheus contains metrics for all the clusters, including a filed cluster on each document.

We need to add this cluster on all the queries to obtain data only for the cluster where the benckmark is executed, like:

query: kubernetes_build_info{cluster="{{.CLUSTER_NAME}}"}

This variable must be set before executing kube-burner, like:

CLUSTER_NAME="mrnd-aks" /home/morenod/software/kube-burner/bin/amd64/kube-burner init -c hcp-density-aks.yml -u $PROM_URL -t $TOKEN -m ../metric-profile.yaml --skip-tls-verify
